### PR TITLE
CI: upgrade pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
 install:
   - source ./ci/install.sh
   - conda install -y python=${CONDA_PYTHON}
+  - conda install -y pip
   - pip install -r requirements.txt
   - pip install twine cibuildwheel==1.1.0
   - |-


### PR DESCRIPTION
The errors are probably because the version that is running is too old.