### PR TITLE
Curve improvements: length computations and closest point search

### DIFF
--- a/src/splipy/basis.py
+++ b/src/splipy/basis.py
@@ -15,7 +15,7 @@ from . import state
 from .utils import ensure_listlike_old
 
 if TYPE_CHECKING:
-    from .typing import ArrayLike, FloatArray, ScalarLike
+    from .typing import ArrayLike, FloatArray, Scalar
 
 __all__ = ["BSplineBasis"]
 
@@ -151,7 +151,7 @@ class BSplineBasis:
     @overload
     def evaluate(
         self,
-        t: ArrayLike | ScalarLike,
+        t: ArrayLike | Scalar,
         d: int = 0,
         from_right: bool = ...,
     ) -> npt.NDArray[np.double]: ...
@@ -159,7 +159,7 @@ class BSplineBasis:
     @overload
     def evaluate(
         self,
-        t: ArrayLike | ScalarLike,
+        t: ArrayLike | Scalar,
         d: int = 0,
         from_right: bool = ...,
         sparse: Literal[False] = ...,
@@ -168,7 +168,7 @@ class BSplineBasis:
     @overload
     def evaluate(
         self,
-        t: ArrayLike | ScalarLike,
+        t: ArrayLike | Scalar,
         d: int = 0,
         from_right: bool = ...,
         sparse: Literal[True] = ...,
@@ -176,7 +176,7 @@ class BSplineBasis:
 
     def evaluate(
         self,
-        t: ArrayLike | ScalarLike,
+        t: ArrayLike | Scalar,
         d: int = 0,
         from_right: bool = True,
         sparse: bool = False,
@@ -285,7 +285,7 @@ class BSplineBasis:
         N = csr_matrix((data, indices, indptr), (m, n))
         return N.toarray() if sparse else N
 
-    def integrate(self, t0: ScalarLike, t1: ScalarLike) -> FloatArray:
+    def integrate(self, t0: Scalar, t1: Scalar) -> FloatArray:
         """Integrate all basis functions over a given domain
 
         :param float t0: The parametric starting point
@@ -327,7 +327,7 @@ class BSplineBasis:
         self -= self.start()  # set start-point to 0
         self /= self.end()  # set end-point to 1
 
-    def reparam(self, start: ScalarLike = 0, end: ScalarLike = 1) -> None:
+    def reparam(self, start: Scalar = 0, end: Scalar = 1) -> None:
         """Set the parametric domain to be (start, end)
 
         :raises ValueError: If *end* ≤ *start*
@@ -347,7 +347,7 @@ class BSplineBasis:
         b = self.end()
         self.knots = (self.knots[::-1] - a) / (b - a) * (a - b) + b
 
-    def knot_continuity(self, knot: ScalarLike) -> int:
+    def knot_continuity(self, knot: Scalar) -> int:
         """Get the continuity of the basis functions at a given point.
 
         This is similar to continuity(), but throws an error if the input is not
@@ -375,7 +375,7 @@ class BSplineBasis:
             raise NotAKnotError
         return self.order - (hi - lo) - 1
 
-    def continuity(self, knot: ScalarLike) -> int | float:
+    def continuity(self, knot: Scalar) -> int | float:
         """Get the continuity of the basis functions at a given point.
 
         :return: *p*--*m*--1 at a knot with multiplicity *m*, or ``inf``
@@ -387,7 +387,7 @@ class BSplineBasis:
         except NotAKnotError:
             return np.inf
 
-    def min_continuity(self, knot: ScalarLike, max: int) -> int:
+    def min_continuity(self, knot: Scalar, max: int) -> int:
         """Get the min of the continuity at a given point and an upper bound.
 
         :return: min(self.continuity(knot), max)
@@ -498,7 +498,7 @@ class BSplineBasis:
 
         return BSplineBasis(p, knots, self.periodic)
 
-    def insert_knot(self, new_knot: ScalarLike) -> FloatArray:
+    def insert_knot(self, new_knot: Scalar) -> FloatArray:
         """Inserts a knot in the knot vector.
 
         The return value is a sparse matrix *C* (actually, a dense matrix with
@@ -641,19 +641,19 @@ class BSplineBasis:
         """Returns the knot at a given index."""
         return float(self.knots[i])
 
-    def __iadd__(self, a: ScalarLike) -> Self:
+    def __iadd__(self, a: Scalar) -> Self:
         self.knots += float(a)
         return self
 
-    def __isub__(self, a: ScalarLike) -> Self:
+    def __isub__(self, a: Scalar) -> Self:
         self.knots -= float(a)
         return self
 
-    def __imul__(self, a: ScalarLike) -> Self:
+    def __imul__(self, a: Scalar) -> Self:
         self.knots *= float(a)
         return self
 
-    def __itruediv__(self, a: ScalarLike) -> Self:
+    def __itruediv__(self, a: Scalar) -> Self:
         self.knots /= float(a)
         return self
 

--- a/src/splipy/curve.py
+++ b/src/splipy/curve.py
@@ -375,8 +375,11 @@ class Curve(SplineObject):
         .. math:: \\int_{t_0}^{t_1}\\sqrt{x(t)^2 + y(t)^2 + z(t)^2} dt
 
         """
-        (x, w) = np.polynomial.legendre.leggauss(self.order(0) + 1)
         knots = self.knots(0)
+        quadrature_points = self.order(0) + 1
+        if len(knots) == 2:
+            quadrature_points *= 2
+        (x, w) = np.polynomial.legendre.leggauss(quadrature_points)
         # keep only integration boundaries within given start (t0) and stop (t1) interval
         if t0 is not None:
             t0 = float(t0)

--- a/src/splipy/curve.py
+++ b/src/splipy/curve.py
@@ -7,7 +7,6 @@ import numpy as np
 import scipy.sparse.linalg as splinalg
 
 from . import state
-
 from .basis import BSplineBasis
 from .splineobject import SplineObject
 from .utils import ensure_listlike, is_singleton
@@ -427,62 +426,60 @@ class Curve(SplineObject):
 
         # return new resampled curve
         return Curve(basis, controlpoints)
-    
+
     def _closest_point_linear_curve(self, pt: ArrayLike) -> tuple[FloatArray, float]:
         """Computes the closest point on a linear curve to a given point.
         :param array-like pt: point to which the closest point on the curve is sought
         :return: the closest point on the curve and its parametric location
         :rtype: tuple(numpy.array, float)
-    
+
         """
         knots = self.knots(0)
-        mindist_squared = np.linalg.norm(pt - self.controlpoints[0])**2
+        mindist_squared = np.linalg.norm(pt - self.controlpoints[0]) ** 2
         t = knots[0]
-        for p1,p0,t1,t0 in zip(self.controlpoints[1:], self.controlpoints[:-1],
-                              knots[2:-1], knots[1:-2]):
+        for p1, p0, t1, t0 in zip(self.controlpoints[1:], self.controlpoints[:-1], knots[2:-1], knots[1:-2]):
             b = p1 - p0
             a = pt - p0
-            if 0 <= np.dot(a,b) <= np.dot(b,b):
-                dist_squared = np.dot(a,a) - np.dot(a,b)**2 / np.dot(b,b)
+            if 0 <= np.dot(a, b) <= np.dot(b, b):
+                dist_squared = np.dot(a, a) - np.dot(a, b) ** 2 / np.dot(b, b)
                 if dist_squared < mindist_squared:
                     mindist_squared = dist_squared
-                    t = t0 + (np.dot(a,b) / np.dot(b,b)) * (t1 - t0)
-                if np.dot(p1-pt,p1-p0) < mindist_squared:
-                    mindist_squared = np.dot(p1-pt,p1-pt)
+                    t = t0 + (np.dot(a, b) / np.dot(b, b)) * (t1 - t0)
+                if np.dot(p1 - pt, p1 - p0) < mindist_squared:
+                    mindist_squared = np.dot(p1 - pt, p1 - pt)
                     t = t1
-        return self(t),t
+        return self(t), t
 
-    def closest_point(self, pt : ArrayLike, t0 : Scalar = None) -> tuple[FloatArray, float]:
+    def closest_point(self, pt: ArrayLike, t0: Scalar = None) -> tuple[FloatArray, float]:
         """Computes the closest point on this curve to a given point. This is done by newton iteration
-        and is using the state variables `controlpoint_absolute_tolerance` and `controlpoint_relative_tolerance`
+        and is using the state variables `controlpoint_absolute_tolerance`
         to determine convergence; but limited to 15 iterations.
         :param array-like pt: point to which the closest point on the curve is sought
         :param float t0: optional starting guess for the parametric location of the closest point
         :return: the closest point on the curve and its parametric location
         :rtype: tuple(numpy.array, float)
-    
+
         """
         if self.order(0) == 1:
             return self._closest_point_linear_curve(pt)
 
         if t0 is None:
-            dist = [np.linalg.norm(cp-pt) for cp in self.controlpoints]
+            dist = [np.linalg.norm(cp - pt) for cp in self.controlpoints]
         i = np.argmin(dist)
         t0 = self.bases[0].greville(i)
         t = t0
         iter = 0
         atol = state.controlpoint_absolute_tolerance
-        rtol = state.controlpoint_relative_tolerance
         F = np.dot(self(t) - pt, self.derivative(t))
         while np.abs(F) > atol:
             x = self(t)
             dx = self.derivative(t)
             ddx = self.derivative(t, d=2)
-            e  = x - pt
-            dF = np.dot(dx,dx) + np.dot(e, ddx)
+            e = x - pt
+            dF = np.dot(dx, dx) + np.dot(e, ddx)
             dt = -F / dF
             # closest point outside curve definition. Return the closest endpoint
-            if (t==self.bases[0].start() and dt < 0) or (t==self.bases[0].end() and dt > 0):
+            if (t == self.bases[0].start() and dt < 0) or (t == self.bases[0].end() and dt > 0):
                 break
             t += dt
             t = np.clip(t, self.bases[0].start(), self.bases[0].end())

--- a/src/splipy/curve.py
+++ b/src/splipy/curve.py
@@ -15,7 +15,7 @@ from .utils import ensure_listlike, is_singleton
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from .typing import ArrayLike, Direction, FloatArray, ScalarLike
+    from .typing import ArrayLike, Direction, FloatArray, Scalar
 
 __all__ = ["Curve"]
 
@@ -47,7 +47,7 @@ class Curve(SplineObject):
         """
         super().__init__([basis], controlpoints, rational, raw=raw)
 
-    def evaluate(self, *params: ArrayLike | ScalarLike, tensor: bool = True) -> FloatArray:
+    def evaluate(self, *params: ArrayLike | Scalar, tensor: bool = True) -> FloatArray:
         """Evaluate the object at given parametric values.
 
         This function returns an *n1* × *n2* × ... × *dim* array, where *ni* is
@@ -87,7 +87,7 @@ class Curve(SplineObject):
 
     def derivative(
         self,
-        *params: ArrayLike | ScalarLike,
+        *params: ArrayLike | Scalar,
         d: int | Sequence[int] = 1,
         above: bool | Sequence[bool] = True,
         tensor: bool = True,
@@ -146,7 +146,7 @@ class Curve(SplineObject):
 
         return result
 
-    def binormal(self, t: ArrayLike | ScalarLike, above: bool = True) -> FloatArray:
+    def binormal(self, t: ArrayLike | Scalar, above: bool = True) -> FloatArray:
         """Evaluate the normalized binormal of the curve at the given parametric value(s).
 
         This function returns an *n* × 3 array, where *n* is the number of
@@ -194,7 +194,7 @@ class Curve(SplineObject):
 
         return result / magnitude
 
-    def normal(self, t: ArrayLike | ScalarLike, above: bool = True) -> FloatArray:
+    def normal(self, t: ArrayLike | Scalar, above: bool = True) -> FloatArray:
         """Evaluate the normal of the curve at the given parametric value(s).
 
         This function returns an *n* × 3 array, where *n* is the number of
@@ -219,7 +219,7 @@ class Curve(SplineObject):
 
         return np.cross(B, T)
 
-    def curvature(self, t: ArrayLike | ScalarLike, above: bool = True) -> FloatArray | float:
+    def curvature(self, t: ArrayLike | Scalar, above: bool = True) -> FloatArray | float:
         """Evaluate the curvaure at specified point(s). The curvature is defined as
 
         .. math:: \\frac{|\\boldsymbol{v}\\times \\boldsymbol{a}|}{|\\boldsymbol{v}|^3}
@@ -243,7 +243,7 @@ class Curve(SplineObject):
         speed: FloatArray = np.linalg.norm(v, axis=-1)
         return magnitude / speed**3
 
-    def torsion(self, t: ArrayLike | ScalarLike, above: bool = True) -> FloatArray | float:
+    def torsion(self, t: ArrayLike | Scalar, above: bool = True) -> FloatArray | float:
         """Evaluate the torsion for a 3D curve at specified point(s). The torsion is defined as
 
         .. math:: \\frac{(\\boldsymbol{v}\\times \\boldsymbol{a})\\cdot
@@ -361,7 +361,7 @@ class Curve(SplineObject):
 
         return self
 
-    def continuity(self, knot: ScalarLike) -> int | float:
+    def continuity(self, knot: Scalar) -> int | float:
         """Get the parametric continuity of the curve at a given point. Will
         return p-1-m, where m is the knot multiplicity and inf between knots"""
         return self.bases[0].continuity(knot)
@@ -371,7 +371,7 @@ class Curve(SplineObject):
         continuity"""
         return np.array([k for k in self.knots(0) if self.continuity(k) < 1], dtype=np.float64)
 
-    def length(self, t0: ScalarLike | None = None, t1: ScalarLike | None = None) -> float:
+    def length(self, t0: Scalar | None = None, t1: Scalar | None = None) -> float:
         """Computes the euclidian length of the curve in geometric space
 
         .. math:: \\int_{t_0}^{t_1}\\sqrt{x(t)^2 + y(t)^2 + z(t)^2} dt
@@ -428,7 +428,7 @@ class Curve(SplineObject):
         # return new resampled curve
         return Curve(basis, controlpoints)
 
-    def closest_point(self, pt : ArrayLike, t0 : ScalarLike = None) -> tuple[FloatArray, float]:
+    def closest_point(self, pt : ArrayLike, t0 : Scalar = None) -> tuple[FloatArray, float]:
         """Computes the closest point on this curve to a given point. This is done by newton iteration
         and is using the state variables `controlpoint_absolute_tolerance` and `controlpoint_relative_tolerance`
         to determine convergence; but limited to 15 iterations.

--- a/src/splipy/splineobject.py
+++ b/src/splipy/splineobject.py
@@ -23,7 +23,7 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
-    from .typing import ArrayLike, Direction, FloatArray, ScalarLike, SectionElement, SectionKwargs
+    from .typing import ArrayLike, Direction, FloatArray, Scalar, SectionElement, SectionKwargs
 
 __all__ = ["SplineObject"]
 
@@ -149,7 +149,7 @@ class SplineObject:
 
     def evaluate(
         self,
-        *params: ArrayLike | ScalarLike,
+        *params: ArrayLike | Scalar,
         tensor: bool = True,
     ) -> FloatArray:
         """Evaluate the object at given parametric values.
@@ -201,7 +201,7 @@ class SplineObject:
 
     def derivative(
         self,
-        *params: ArrayLike | ScalarLike,
+        *params: ArrayLike | Scalar,
         d: int | Sequence[int] = 1,
         above: bool | Sequence[bool] = True,
         tensor: bool = True,
@@ -358,7 +358,7 @@ class SplineObject:
     @overload
     def tangent(
         self,
-        *params: ArrayLike | ScalarLike,
+        *params: ArrayLike | Scalar,
         direction: Direction,
         above: bool | Sequence[bool] = True,
         tensor: bool = True,
@@ -367,7 +367,7 @@ class SplineObject:
     @overload
     def tangent(
         self,
-        *params: ArrayLike | ScalarLike,
+        *params: ArrayLike | Scalar,
         direction: None = None,
         above: bool | Sequence[bool] = True,
         tensor: bool = True,
@@ -375,7 +375,7 @@ class SplineObject:
 
     def tangent(
         self,
-        *params: ArrayLike | ScalarLike,
+        *params: ArrayLike | Scalar,
         direction: Direction | None = None,
         above: bool | Sequence[bool] = True,
         tensor: bool = True,
@@ -789,7 +789,7 @@ class SplineObject:
 
         return self
 
-    def insert_knot(self, knot: ScalarLike | ArrayLike, direction: Direction = 0) -> Self:
+    def insert_knot(self, knot: Scalar | ArrayLike, direction: Direction = 0) -> Self:
         """Insert a new knot into the spline.
 
         :param int direction: The direction to insert in
@@ -866,14 +866,14 @@ class SplineObject:
         return self
 
     @overload
-    def reparam(self, *args: tuple[ScalarLike, ScalarLike]) -> Self: ...
+    def reparam(self, *args: tuple[Scalar, Scalar]) -> Self: ...
 
     @overload
-    def reparam(self, arg: tuple[ScalarLike, ScalarLike] = ..., /, *, direction: Direction) -> Self: ...
+    def reparam(self, arg: tuple[Scalar, Scalar] = ..., /, *, direction: Direction) -> Self: ...
 
     def reparam(
         self,
-        *args: tuple[ScalarLike, ScalarLike],
+        *args: tuple[Scalar, Scalar],
         direction: Direction | None = None,
     ) -> Self:
         """Redefine the parametric domain. This function accepts two calling
@@ -961,9 +961,9 @@ class SplineObject:
     def scale(self, arg: ArrayLike, /) -> Self: ...
 
     @overload
-    def scale(self, arg: ScalarLike, *args: ScalarLike) -> Self: ...
+    def scale(self, arg: Scalar, *args: Scalar) -> Self: ...
 
-    def scale(self, arg: ArrayLike | ScalarLike, *args: ScalarLike) -> Self:
+    def scale(self, arg: ArrayLike | Scalar, *args: Scalar) -> Self:
         """Scale, or magnify the object by a given amount.
 
         In case of one input argument, the scaling is uniform.
@@ -1275,7 +1275,7 @@ class SplineObject:
 
         return self
 
-    def split(self, knots: ScalarLike | ArrayLike, direction: Direction = 0) -> Self | list[Self]:
+    def split(self, knots: Scalar | ArrayLike, direction: Direction = 0) -> Self | list[Self]:
         """Split an object into two or more separate representations with C0
         continuity between them.
 
@@ -1497,11 +1497,11 @@ class SplineObject:
         self.translate(-np.asarray(x, dtype=np.float64))  # can't do -x if x is a list, so we rewrap it here
         return self
 
-    def __imul__(self, x: ArrayLike | ScalarLike) -> Self:
+    def __imul__(self, x: ArrayLike | Scalar) -> Self:
         self.scale(x)
         return self
 
-    def __itruediv__(self, x: ArrayLike | ScalarLike) -> Self:
+    def __itruediv__(self, x: ArrayLike | Scalar) -> Self:
         self.scale(1.0 / np.asarray(x, dtype=np.float64))
         return self
 
@@ -1520,15 +1520,15 @@ class SplineObject:
         new_obj -= x
         return new_obj
 
-    def __mul__(self, x: ArrayLike | ScalarLike) -> Self:
+    def __mul__(self, x: ArrayLike | Scalar) -> Self:
         new_obj = copy.deepcopy(self)
         new_obj *= x
         return new_obj
 
-    def __rmul__(self, x: ArrayLike | ScalarLike) -> Self:
+    def __rmul__(self, x: ArrayLike | Scalar) -> Self:
         return self * x
 
-    def __truediv__(self, x: ArrayLike | ScalarLike) -> Self:
+    def __truediv__(self, x: ArrayLike | Scalar) -> Self:
         new_obj = copy.deepcopy(self)
         new_obj /= x
         return new_obj

--- a/src/splipy/surface.py
+++ b/src/splipy/surface.py
@@ -13,7 +13,7 @@ from .utils import check_direction, ensure_listlike, is_singleton, sections
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from .typing import ArrayLike, Direction, FloatArray, ScalarLike
+    from .typing import ArrayLike, Direction, FloatArray, Scalar
 
 __all__ = ["Surface"]
 
@@ -49,8 +49,8 @@ class Surface(SplineObject):
 
     def normal(
         self,
-        u: ArrayLike | ScalarLike,
-        v: ArrayLike | ScalarLike,
+        u: ArrayLike | Scalar,
+        v: ArrayLike | Scalar,
         above: bool | Sequence[bool] = True,
         tensor: bool = True,
     ) -> FloatArray:
@@ -107,7 +107,7 @@ class Surface(SplineObject):
 
     def derivative(
         self,
-        *params: ArrayLike | ScalarLike,
+        *params: ArrayLike | Scalar,
         d: int | Sequence[int] = 1,
         above: bool | Sequence[bool] = True,
         tensor: bool = True,
@@ -290,7 +290,7 @@ class Surface(SplineObject):
             tuple(self.section(*args) for args in sections(2, 1)),
         )
 
-    def const_par_curve(self, knot: ScalarLike, direction: Direction) -> Curve:
+    def const_par_curve(self, knot: Scalar, direction: Direction) -> Curve:
         """Get a Curve representation of the parametric line of some constant
         knot value.
         :param float knot: The constant knot value to sample the surface

--- a/src/splipy/typing.py
+++ b/src/splipy/typing.py
@@ -8,7 +8,7 @@ import numpy.typing as npt
 B = TypeVar("B", bound=npt.NBitBase)
 
 ArrayLike: TypeAlias = npt.ArrayLike
-ScalarLike: TypeAlias = SupportsFloat
+Scalar: TypeAlias = SupportsFloat
 FloatArray: TypeAlias = npt.NDArray[np.floating]
 Direction: TypeAlias = Literal["u", "v", "w", "U", "V", "W"] | int
 SectionElement: TypeAlias = Literal[-1, 0] | None

--- a/tests/curve_test.py
+++ b/tests/curve_test.py
@@ -493,6 +493,17 @@ class TestCurve(unittest.TestCase):
         self.assertAlmostEqual(crv.length(), 1.0)
         crv = Curve(BSplineBasis(2, [-1, -1, 1, 2, 3, 3]), [[0, 0, 0], [1, 0, 0], [1, 0, 3], [1, 10, 3]])
         self.assertAlmostEqual(crv.length(), 14.0)
+        basis = BSplineBasis(order=4, knots = [0,0,0,0,1,1,1,1])
+        curve = Curve(basis, [[-1,0],[0,1],[0,1],[1,0]])
+        self.assertAlmostEqual(curve.length(), 2.54861512024293, places=4)
+        waves = Curve(basis, [[-1,0],[0,-1],[0,1],[1,0]])
+        self.assertAlmostEqual(waves.length(), 2.3709893215943936, places=3)
+        peak = Curve(basis, [[-1,0],[1,1],[-1,1],[1,0]])
+        self.assertAlmostEqual(peak.length(), 2.54861512024293, places=1)
+        loop = Curve(basis, [[-1,0],[5,1],[-5,1],[1,0]])
+        self.assertAlmostEqual(loop.length(), 6.319416448472324, places=2)
+        zigzack = Curve(basis, [[-1,0],[5,-1],[-5,1],[1,0]])
+        self.assertAlmostEqual(zigzack.length(), 6.131548783913573, places=1)
 
     def test_make_periodic(self):
         my_cps = np.array([[0, -1], [1, 0], [0, 1], [-1, 0], [0, -1]], dtype=float)

--- a/tests/curve_test.py
+++ b/tests/curve_test.py
@@ -487,7 +487,7 @@ class TestCurve(unittest.TestCase):
         pt = crv2(t)
         pt2 = crv3(t + 1.0)
         self.assertAlmostEqual(np.linalg.norm(pt - pt2), 0.0)
-    
+
     def test_closest_point(self):
         # quadratic curve x(t) = t(2-t), y(t) = 1-t^2
         crv = Curve(BSplineBasis(3), [[0, 1], [1, 1], [1, 0]])
@@ -517,24 +517,24 @@ class TestCurve(unittest.TestCase):
         self.assertAlmostEqual(t, 1.0)
 
         # test nontrivial away from t=4/5 (exact normal n=[4,1])
-        pt, t = crv.closest_point([24/25+12, 9/25+3])
-        self.assertAlmostEqual(pt[0], 24/25)
-        self.assertAlmostEqual(pt[1],  9/25)
-        self.assertAlmostEqual(t, 0.8) 
+        pt, t = crv.closest_point([24 / 25 + 12, 9 / 25 + 3])
+        self.assertAlmostEqual(pt[0], 24 / 25)
+        self.assertAlmostEqual(pt[1], 9 / 25)
+        self.assertAlmostEqual(t, 0.8)
 
         # test on the curve itself
-        pt, t = crv.closest_point([0.19, .99])
-        self.assertAlmostEqual(pt[0], .19)
-        self.assertAlmostEqual(pt[1], .99)
-        self.assertAlmostEqual(t, 0.1) 
+        pt, t = crv.closest_point([0.19, 0.99])
+        self.assertAlmostEqual(pt[0], 0.19)
+        self.assertAlmostEqual(pt[1], 0.99)
+        self.assertAlmostEqual(t, 0.1)
 
         crv = cf.line([0, 0], [1, 1])
-        pt,t = crv.closest_point([0.3, 0.3])
+        pt, t = crv.closest_point([0.3, 0.3])
         expects = np.array([0.3, 0.3])
         self.assertAlmostEqual(np.linalg.norm(pt - expects), 0.0)
         self.assertAlmostEqual(t, 0.3)
 
-        pt,t = crv.closest_point([0.5, 0.0])
+        pt, t = crv.closest_point([0.5, 0.0])
         expects = np.array([0.25, 0.25])
         self.assertAlmostEqual(np.linalg.norm(pt - expects), 0.0)
         self.assertAlmostEqual(t, 0.25)
@@ -544,16 +544,16 @@ class TestCurve(unittest.TestCase):
         self.assertAlmostEqual(crv.length(), 1.0)
         crv = Curve(BSplineBasis(2, [-1, -1, 1, 2, 3, 3]), [[0, 0, 0], [1, 0, 0], [1, 0, 3], [1, 10, 3]])
         self.assertAlmostEqual(crv.length(), 14.0)
-        basis = BSplineBasis(order=4, knots = [0,0,0,0,1,1,1,1])
-        curve = Curve(basis, [[-1,0],[0,1],[0,1],[1,0]])
+        basis = BSplineBasis(order=4, knots=[0, 0, 0, 0, 1, 1, 1, 1])
+        curve = Curve(basis, [[-1, 0], [0, 1], [0, 1], [1, 0]])
         self.assertAlmostEqual(curve.length(), 2.54861512024293, places=4)
-        waves = Curve(basis, [[-1,0],[0,-1],[0,1],[1,0]])
+        waves = Curve(basis, [[-1, 0], [0, -1], [0, 1], [1, 0]])
         self.assertAlmostEqual(waves.length(), 2.3709893215943936, places=3)
-        peak = Curve(basis, [[-1,0],[1,1],[-1,1],[1,0]])
+        peak = Curve(basis, [[-1, 0], [1, 1], [-1, 1], [1, 0]])
         self.assertAlmostEqual(peak.length(), 2.54861512024293, places=1)
-        loop = Curve(basis, [[-1,0],[5,1],[-5,1],[1,0]])
+        loop = Curve(basis, [[-1, 0], [5, 1], [-5, 1], [1, 0]])
         self.assertAlmostEqual(loop.length(), 6.319416448472324, places=2)
-        zigzack = Curve(basis, [[-1,0],[5,-1],[-5,1],[1,0]])
+        zigzack = Curve(basis, [[-1, 0], [5, -1], [-5, 1], [1, 0]])
         self.assertAlmostEqual(zigzack.length(), 6.131548783913573, places=1)
 
     def test_make_periodic(self):

--- a/tests/curve_test.py
+++ b/tests/curve_test.py
@@ -489,34 +489,55 @@ class TestCurve(unittest.TestCase):
         self.assertAlmostEqual(np.linalg.norm(pt - pt2), 0.0)
     
     def test_closest_point(self):
+        # quadratic curve x(t) = t(2-t), y(t) = 1-t^2
         crv = Curve(BSplineBasis(3), [[0, 1], [1, 1], [1, 0]])
+
+        # test away from diagonal x=y
         pt, t = crv.closest_point([0.8, 0.8])
         self.assertAlmostEqual(pt[0], 0.75)
         self.assertAlmostEqual(pt[1], 0.75)
         self.assertAlmostEqual(t, 0.5)
 
+        # test other side of diagonal x=y
+        pt, t = crv.closest_point([0.6, 0.6])
+        self.assertAlmostEqual(pt[0], 0.75)
+        self.assertAlmostEqual(pt[1], 0.75)
+        self.assertAlmostEqual(t, 0.5)
+
+        # test endpoint (start)
         pt, t = crv.closest_point([0.0, 0.4])
         self.assertAlmostEqual(pt[0], 0.00)
         self.assertAlmostEqual(pt[1], 1.00)
         self.assertAlmostEqual(t, 0.0)
 
+        # test endpoint (stop)
         pt, t = crv.closest_point([0.0, -0.1])
         self.assertAlmostEqual(pt[0], 1.00)
         self.assertAlmostEqual(pt[1], 0.00)
         self.assertAlmostEqual(t, 1.0)
 
-        # crv = cf.line([0, 0], [1, 1])
-        # pt,t = crv.closest_point([0.3, 0.3])
-        # expects = np.array([0.3, 0.3])
-        # print(expects)
-        # print(pt)
-        # self.assertAlmostEqual(np.linalg.norm(pt - expects), 0.0)
-        # self.assertAlmostEqual(t, 0.3)
+        # test nontrivial away from t=4/5 (exact normal n=[4,1])
+        pt, t = crv.closest_point([24/25+12, 9/25+3])
+        self.assertAlmostEqual(pt[0], 24/25)
+        self.assertAlmostEqual(pt[1],  9/25)
+        self.assertAlmostEqual(t, 0.8) 
 
-        # pt,t = crv.closest_point([0.5, 0.0])
-        # expects = np.array([0.25, 0.25])
-        # self.assertAlmostEqual(np.linalg.norm(pt - expects), 0.0)
-        # self.assertAlmostEqual(t, 0.25)
+        # test on the curve itself
+        pt, t = crv.closest_point([0.19, .99])
+        self.assertAlmostEqual(pt[0], .19)
+        self.assertAlmostEqual(pt[1], .99)
+        self.assertAlmostEqual(t, 0.1) 
+
+        crv = cf.line([0, 0], [1, 1])
+        pt,t = crv.closest_point([0.3, 0.3])
+        expects = np.array([0.3, 0.3])
+        self.assertAlmostEqual(np.linalg.norm(pt - expects), 0.0)
+        self.assertAlmostEqual(t, 0.3)
+
+        pt,t = crv.closest_point([0.5, 0.0])
+        expects = np.array([0.25, 0.25])
+        self.assertAlmostEqual(np.linalg.norm(pt - expects), 0.0)
+        self.assertAlmostEqual(t, 0.25)
 
     def test_length(self):
         crv = Curve()

--- a/tests/curve_test.py
+++ b/tests/curve_test.py
@@ -487,6 +487,36 @@ class TestCurve(unittest.TestCase):
         pt = crv2(t)
         pt2 = crv3(t + 1.0)
         self.assertAlmostEqual(np.linalg.norm(pt - pt2), 0.0)
+    
+    def test_closest_point(self):
+        crv = Curve(BSplineBasis(3), [[0, 1], [1, 1], [1, 0]])
+        pt, t = crv.closest_point([0.8, 0.8])
+        self.assertAlmostEqual(pt[0], 0.75)
+        self.assertAlmostEqual(pt[1], 0.75)
+        self.assertAlmostEqual(t, 0.5)
+
+        pt, t = crv.closest_point([0.0, 0.4])
+        self.assertAlmostEqual(pt[0], 0.00)
+        self.assertAlmostEqual(pt[1], 1.00)
+        self.assertAlmostEqual(t, 0.0)
+
+        pt, t = crv.closest_point([0.0, -0.1])
+        self.assertAlmostEqual(pt[0], 1.00)
+        self.assertAlmostEqual(pt[1], 0.00)
+        self.assertAlmostEqual(t, 1.0)
+
+        # crv = cf.line([0, 0], [1, 1])
+        # pt,t = crv.closest_point([0.3, 0.3])
+        # expects = np.array([0.3, 0.3])
+        # print(expects)
+        # print(pt)
+        # self.assertAlmostEqual(np.linalg.norm(pt - expects), 0.0)
+        # self.assertAlmostEqual(t, 0.3)
+
+        # pt,t = crv.closest_point([0.5, 0.0])
+        # expects = np.array([0.25, 0.25])
+        # self.assertAlmostEqual(np.linalg.norm(pt - expects), 0.0)
+        # self.assertAlmostEqual(t, 0.25)
 
     def test_length(self):
         crv = Curve()


### PR DESCRIPTION
Three changes:

* Fixes #188 (better accuracy for `curve.length`)
* Implemented `curve.closest_point`
* Changes ScalarLike to Scalar